### PR TITLE
Change de_De to de_DE everywhere

### DIFF
--- a/app/code/community/Fooman/Common/modman
+++ b/app/code/community/Fooman/Common/modman
@@ -2,6 +2,6 @@
 ../../../../../app/design/adminhtml/default/default/layout/fooman_common.xml  /app/design/adminhtml/default/default/layout/fooman_common.xml
 ../../../../../app/design/adminhtml/default/default/template/fooman/common/   /app/design/adminhtml/default/default/template/fooman/common/
 ../../../../../app/etc/modules/Fooman_Common.xml                              /app/etc/modules/Fooman_Common.xml
-../../../../../app/locale/de_De/Fooman_Common.csv                             /app/locale/de_De/Fooman_Common.csv
+../../../../../app/locale/de_DE/Fooman_Common.csv                             /app/locale/de_DE/Fooman_Common.csv
 ../../../../../app/locale/en_US/Fooman_Common.csv                             /app/locale/en_US/Fooman_Common.csv
 ../../../../../app/locale/it_IT/Fooman_Common.csv                             /app/locale/it_IT/Fooman_Common.csv

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,8 @@
                 "app/etc/modules/Fooman_Common.xml"
             ],
             [
-                "app/locale/de_De/Fooman_Common.csv",
-                "app/locale/de_De/Fooman_Common.csv"
+                "app/locale/de_DE/Fooman_Common.csv",
+                "app/locale/de_DE/Fooman_Common.csv"
             ],
             [
                 "app/locale/en_US/Fooman_Common.csv",


### PR DESCRIPTION
git grep -ilz de_De | xargs -0 gsed -ie 's/de_De/de_DE/g'

This was killing composer —optimize-autoloader on a case sensitive
filesystem, I didn’t really check why, I just did this instead. I’d
guess that the [extra][map] section of the composer file is superfluous
as it’s also in modman?